### PR TITLE
fix: reset timer state on question change to fix Safari timer bug

### DIFF
--- a/app/quiz/play/[gameId]/page.js
+++ b/app/quiz/play/[gameId]/page.js
@@ -61,6 +61,8 @@ export default function PlayGamePage() {
           setSelectedAnswer(null);
           setHasAnswered(false);
           setAnswerResult(null);
+          // Reset timer state to prevent Safari from using stale timestamps
+          setLocalQuestionStartTime(null);
         }
       }
 


### PR DESCRIPTION
Fixes an issue where on old iPhone Safari browsers, the quiz timer would start from 0 for every question, causing answer buttons to be disabled.

The root cause was that when a new question started, the localQuestionStartTime state variable was not being reset. This caused the timer to potentially use stale timestamps from the previous question if Firebase sync was delayed on Safari, resulting in:
- Calculated elapsed time including time from previous question
- Timer immediately showing 0 seconds remaining
- Answer buttons being disabled on load

The fix resets localQuestionStartTime to null when a new question is detected, ensuring the timer always starts fresh with either the new server timestamp or a fresh local fallback timestamp.